### PR TITLE
added TEST_DATABASE_URL example

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -16,3 +16,8 @@ PRISMA_HIDE_UPDATE_MESSAGE=true
 # trace | info | debug | warn | error | silent
 # LOG_LEVEL=debug
 
+# Setup a testing db on your own device.
+# This requires that you setup a db on your local device.
+# You can use the following below or edit it on your on .env:
+
+TEST_DATABASE_URL=postgresql://app:app@localhost:5432/hybrid-territory-test

--- a/.env.defaults
+++ b/.env.defaults
@@ -17,7 +17,6 @@ PRISMA_HIDE_UPDATE_MESSAGE=true
 # LOG_LEVEL=debug
 
 # Setup a testing db on your own device.
-# This requires that you setup a db on your local device.
 # You can use the following below or edit it on your on .env:
 
 TEST_DATABASE_URL=postgresql://app:app@localhost:5432/hybrid-territory-test


### PR DESCRIPTION
Added a `TEST_DATABASE_URL` env variable as an example in the `.env.defaults` for testing. In order to run the full jest suite, create a testing db.