### PR TITLE
CU-3g9epxz_add-button-from-my-territories-to-self-checkout_Logan-Ricard

### DIFF
--- a/web/src/components/Navbar/Navbar.tsx
+++ b/web/src/components/Navbar/Navbar.tsx
@@ -17,7 +17,7 @@ const Navbar = () => {
   const { isActive, toggle, currentUser } = useContext(layoutContext)
 
   return (
-    <nav className="sticky top-0 py-4 bg-white shadow-lg ">
+    <nav className="sticky top-0 z-10 py-4 bg-white shadow-lg">
       <div className="px-4 mx-auto lg:px-8">
         <div className="flex items-center justify-between gap-5 ">
           <Logo />

--- a/web/src/components/UserListTerritoryCard/UserListTerritoryCard.tsx
+++ b/web/src/components/UserListTerritoryCard/UserListTerritoryCard.tsx
@@ -62,7 +62,7 @@ const UserListTerritoryCard = ({
           heading="Turn in Territory Card?"
           text="This will turn in your territory card and notify the territory servant."
           fn={submitTerritory}
-          className="px-5 py-1 mt-2 font-medium tracking-wider transition-all duration-100 rounded-sm bg-none text-success/50 hover:text-accent active:text-light-blue font-Roboto animate-pulse"
+          className="px-5 py-1 mt-2 font-medium tracking-wider transition-all duration-100 rounded-sm bg-none text-success/60 hover:text-accent active:text-light-blue font-Roboto animate-pulse"
         />
       )}
     </div>

--- a/web/src/components/ViewTerritoryCell/ViewTerritoryCell.tsx
+++ b/web/src/components/ViewTerritoryCell/ViewTerritoryCell.tsx
@@ -122,7 +122,7 @@ export const Success = ({
           }}
           disabled={loading ? true : false}
           variant="custom"
-          className={`tracking-wider text-white bg-error rounded-sm hover:bg-error/70 active:bg-error/70 pt-2 pb-2 ${
+          className={`tracking-wider text-white bg-accent rounded-sm hover:bg-accent/70 active:bg-accent/70 pt-2 pb-2 ${
             loading && 'animate-pulse'
           }`}
         >

--- a/web/src/pages/MyTerritoriesPage/MyTerritoriesPage.tsx
+++ b/web/src/pages/MyTerritoriesPage/MyTerritoriesPage.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from '@redwoodjs/auth'
 import { MetaTags } from '@redwoodjs/web'
+import { Link, routes } from '@redwoodjs/router'
 import { toast, Toaster } from '@redwoodjs/web/dist/toast'
 import Modal from 'src/components/Modal/Modal'
 import { useSendMessageMutation } from 'src/generated/graphql'
@@ -49,7 +50,9 @@ const MyTerritoriesPage = () => {
             text="This will send a text request the territory servant."
             fn={sendMessageRightNow}
           />
-          <Button variant='custom' className='px-10 w-full min-h-[40px] mt-4 font-medium  lg:min-h-[48px]  bg-success hover:bg-success/70 '>Checkout New Territory</Button>
+          <Link to={routes.selfCheckout()}>
+            <Button variant='custom' className='px-10 w-full min-h-[40px] mt-4 font-medium  lg:min-h-[48px]  bg-success hover:bg-success/70 '>Checkout New Territory</Button>
+          </Link>
         </div>
       </div>
 

--- a/web/src/pages/MyTerritoriesPage/MyTerritoriesPage.tsx
+++ b/web/src/pages/MyTerritoriesPage/MyTerritoriesPage.tsx
@@ -42,16 +42,16 @@ const MyTerritoriesPage = () => {
         <div className="w-2/3 mx-auto text-transparent border-b border-off-black lg:mb-4">
           -
         </div>
-        <div className="flex flex-col mx-auto lg:flex-row lg:justify-center lg:gap-4 lg:pb-4 lg:w-2/3">
+        <div className="flex flex-col mx-auto lg:flex-row lg:justify-center lg:gap-4 lg:pb-4 lg:w-3/4">
           <Modal
             title={!isLoading ? 'Request New Territory' : 'Loading...'}
-            className="px-10 py-1 min-h-[40px] w-full mt-4 font-medium tracking-wider text-white transition-all duration-100 rounded-sm lg:min-h-[48px]  active:bg-teal-blue bg-accent hover:bg-accent/70 font-Roboto"
+            className="px-10 py-1 min-h-[40px] w-full mt-4 font-medium text-white transition-all duration-100 rounded-sm lg:min-h-[48px] lg:max-w-[300px] active:bg-teal-blue bg-accent hover:bg-accent/70 font-Roboto"
             heading="Send Territory Request?"
             text="This will send a text request the territory servant."
             fn={sendMessageRightNow}
           />
-          <Link to={routes.selfCheckout()}>
-            <Button variant='custom' className='px-10 w-full min-h-[40px] mt-4 font-medium  lg:min-h-[48px]  bg-success hover:bg-success/70 '>Checkout New Territory</Button>
+          <Link to={routes.selfCheckout()} className='w-full lg:max-w-[300px]'>
+            <Button variant='custom' className='px-10 w-full min-h-[40px] mt-4 font-medium lg:min-h-[48px] bg-success hover:bg-success/70'>Checkout New Territory</Button>
           </Link>
         </div>
       </div>

--- a/web/src/pages/MyTerritoriesPage/MyTerritoriesPage.tsx
+++ b/web/src/pages/MyTerritoriesPage/MyTerritoriesPage.tsx
@@ -4,6 +4,7 @@ import { toast, Toaster } from '@redwoodjs/web/dist/toast'
 import Modal from 'src/components/Modal/Modal'
 import { useSendMessageMutation } from 'src/generated/graphql'
 import UserTerritoriesCell from 'src/components/UserTerritoriesCell'
+import Button from 'src/components/Button/Button'
 
 const MyTerritoriesPage = () => {
   const { currentUser, loading } = useAuth()
@@ -40,13 +41,16 @@ const MyTerritoriesPage = () => {
         <div className="w-2/3 mx-auto text-transparent border-b border-off-black lg:mb-4">
           -
         </div>
-        <Modal
-          title={!isLoading ? 'Request New Territory' : 'Loading...'}
-          className="px-10 py-2 mx-auto mt-4 font-medium tracking-wider text-white transition-all duration-100 rounded-sm lg:mb-4 active:bg-teal-blue bg-accent hover:bg-accent/70 font-Roboto lg:w-1/3"
-          heading="Send Territory Request?"
-          text="This will send a text request the territory servant."
-          fn={sendMessageRightNow}
-        />
+        <div className="flex flex-col mx-auto lg:flex-row lg:justify-center lg:gap-4 lg:pb-4 lg:w-2/3">
+          <Modal
+            title={!isLoading ? 'Request New Territory' : 'Loading...'}
+            className="px-10 py-1 min-h-[40px] w-full mt-4 font-medium tracking-wider text-white transition-all duration-100 rounded-sm lg:min-h-[48px]  active:bg-teal-blue bg-accent hover:bg-accent/70 font-Roboto"
+            heading="Send Territory Request?"
+            text="This will send a text request the territory servant."
+            fn={sendMessageRightNow}
+          />
+          <Button variant='custom' className='px-10 w-full min-h-[40px] mt-4 font-medium  lg:min-h-[48px]  bg-success hover:bg-success/70 '>Checkout New Territory</Button>
+        </div>
       </div>
 
       {!loading && <UserTerritoriesCell userId={currentUser?.id} />}

--- a/web/src/pages/SelfCheckoutPage/SelfCheckoutPage.tsx
+++ b/web/src/pages/SelfCheckoutPage/SelfCheckoutPage.tsx
@@ -12,7 +12,7 @@ const SelfCheckoutPage = () => {
       <div className="flex flex-col w-full">
         <div className="mb-2">
           <Link to={routes.myTerritories()}>
-            <Button variant="custom" className='flex items-center pl-0 font-medium text-dark-blue hover:text-accent active:text-light-blue'>
+            <Button variant="custom" className='flex items-center pl-0 font-medium text-dark-blue hover:text-accent active:text-light-blue lg:ml-12'>
               <MdArrowBack /> My Territories
             </Button>
           </Link>

--- a/web/src/pages/SelfCheckoutPage/SelfCheckoutPage.tsx
+++ b/web/src/pages/SelfCheckoutPage/SelfCheckoutPage.tsx
@@ -1,11 +1,22 @@
+import { MdArrowBack } from 'react-icons/md'
 import { MetaTags } from '@redwoodjs/web'
 import AvailableTerritoriesCell from 'src/components/AvailableTerritoriesCell'
+
+import { Link, routes } from '@redwoodjs/router'
+import Button from 'src/components/Button/Button'
 
 const SelfCheckoutPage = () => {
   return (
     <>
       <MetaTags title="Self-Checkout" description="Self-Checkout page" />
       <div className="flex flex-col w-full">
+        <div className="mb-2">
+          <Link to={routes.myTerritories()}>
+            <Button variant="custom" className='flex items-center pl-0 font-medium text-dark-blue hover:text-accent active:text-light-blue'>
+              <MdArrowBack /> My Territories
+            </Button>
+          </Link>
+        </div>
         <h1 className="text-2xl font-bold font-Roboto text-dark-blue lg:ml-12">
           Self Checkout
         </h1>


### PR DESCRIPTION
Added a new Button to the "Your Territories" page that directs the user the the "Self-Checkout" page.
The button has a different layout depending on the device size.
Then on the "Seld-Checkout" page, there is a new "Back" button that will return the user to the "Your Territories" page.

Also, the color of the "Mark as Not Completed" button on the individual territory card was changed to match the updated Figma design.
And the opacity of the flashing "Turn in Territory" text on the "Your Territories" page was darkened to increase readability.