### PR TITLE
CU-3gfbva8_Fix-Photo-Available-icon-clipping-bug_Logan-Ricard

### DIFF
--- a/web/src/components/Navbar/Navbar.tsx
+++ b/web/src/components/Navbar/Navbar.tsx
@@ -24,7 +24,7 @@ const Navbar = () => {
   const { isActive, toggle } = useContext(layoutContext)
 
   return (
-    <nav className="sticky top-0 py-4 duration-300 bg-white shadow-lg dark:bg-light-black-dark">
+    <nav className="sticky top-0 z-10 py-4 duration-300 bg-white shadow-lg dark:bg-light-black-dark">
       <div className="px-4 mx-auto lg:px-8">
         <div className="flex items-center justify-between gap-5 ">
           <Logo />


### PR DESCRIPTION
Fixed an issue that came back up where the Icon that states if a territory has a photo was clipping through the Top Navbar.
This was fixed with a simple z-index change.